### PR TITLE
Perform S3 transformation on URL

### DIFF
--- a/classes/InVision_WPS3_Hooks.class.php
+++ b/classes/InVision_WPS3_Hooks.class.php
@@ -66,7 +66,7 @@ class Invision_WPS3_Hooks extends Invision_WPS3 {
 			&& ($file = $this->download($id, $url))
 		) return $file;
 
-		return $url;
+		return this->transformUrl($url);
 	}
 
 	public function handleDelete($id) {


### PR DESCRIPTION
Currently the FS path is returned when looking up an image via get_attached_file. This would transform the path to be the S3 path.