### PR TITLE
add isset on port of parse_url

### DIFF
--- a/classes/InVision_WPS3_Hooks.class.php
+++ b/classes/InVision_WPS3_Hooks.class.php
@@ -70,7 +70,7 @@ class Invision_WPS3_Hooks extends Invision_WPS3 {
 
     if (isset($parts['host'])) {
       $pattern = '/^https?:\/\/'.$parts['host'];
-      $pattern .= $parts['port'] ? ":{$parts['port']}" : '';
+      $pattern .= isset($parts['port']) ? ":{$parts['port']}" : '';
       $pattern .= '/';
 
       $dir  = preg_replace($pattern, null, wp_upload_dir()['baseurl']).'/';


### PR DESCRIPTION
This is a fix for:
```
PHP message: PHP Notice: Undefined index: port in /app/user/web/app/plugins/invision-wps3/src/Hooks.php on line 75
```
that is happening in testing, preview and prod on `invision-www-blog-cms` right now.